### PR TITLE
Fix bug in intersection

### DIFF
--- a/src/iter_difference.rs
+++ b/src/iter_difference.rs
@@ -1,15 +1,14 @@
-use std::cmp::Ordering;
 use super::{SortOrder, SortedIterator};
-
-
+use std::cmp::Ordering;
 
 /// Adaptor iterator which outputs the difference of two sorted iterators in
 /// linear time.
 #[derive(Debug)]
 pub struct Difference<I, J>
-    where I: SortedIterator,
-          I::Ordering: SortOrder<I::Item>,
-          J: SortedIterator<Item = I::Item, Ordering = I::Ordering>
+where
+    I: SortedIterator,
+    I::Ordering: SortOrder<I::Item>,
+    J: SortedIterator<Item = I::Item, Ordering = I::Ordering>,
 {
     i: I,
     j: J,
@@ -18,17 +17,19 @@ pub struct Difference<I, J>
 }
 
 impl<I, J> SortedIterator for Difference<I, J>
-    where I: SortedIterator,
-          I::Ordering: SortOrder<I::Item>,
-          J: SortedIterator<Item = I::Item, Ordering = I::Ordering>
+where
+    I: SortedIterator,
+    I::Ordering: SortOrder<I::Item>,
+    J: SortedIterator<Item = I::Item, Ordering = I::Ordering>,
 {
     type Ordering = I::Ordering;
 }
 
 impl<I, J> Iterator for Difference<I, J>
-    where I: SortedIterator,
-          I::Ordering: SortOrder<I::Item>,
-          J: SortedIterator<Item = I::Item, Ordering = I::Ordering>
+where
+    I: SortedIterator,
+    I::Ordering: SortOrder<I::Item>,
+    J: SortedIterator<Item = I::Item, Ordering = I::Ordering>,
 {
     type Item = I::Item;
     fn next(&mut self) -> Option<Self::Item> {
@@ -36,20 +37,18 @@ impl<I, J> Iterator for Difference<I, J>
             let a = self.a.take().or_else(|| self.i.next());
             let b = self.b.take().or_else(|| self.j.next());
             match (a, b) {
-                (Some(a), Some(b)) => {
-                    match I::Ordering::cmp(&a, &b) {
-                        Ordering::Less => {
-                            self.b = Some(b);
-                            return Some(a);
-                        }
-                        Ordering::Greater => {
-                            self.a = Some(a);
-                        }
-                        Ordering::Equal => {
-                            self.b = Some(b);
-                        }
+                (Some(a), Some(b)) => match I::Ordering::cmp(&a, &b) {
+                    Ordering::Less => {
+                        self.b = Some(b);
+                        return Some(a);
                     }
-                }
+                    Ordering::Greater => {
+                        self.a = Some(a);
+                    }
+                    Ordering::Equal => {
+                        self.b = Some(b);
+                    }
+                },
                 (None, None) => return None,
                 (a, None) => return a,
                 (None, _) => (),
@@ -58,23 +57,26 @@ impl<I, J> Iterator for Difference<I, J>
     }
 }
 
-
 /// Extension class for sorted iterators to provide the difference iterator
 /// constructor.
 pub trait DifferenceExt
-    where Self: SortedIterator + Sized,
-          Self::Ordering: SortOrder<Self::Item>
+where
+    Self: SortedIterator + Sized,
+    Self::Ordering: SortOrder<Self::Item>,
 {
     fn difference<J>(self, j: J) -> Difference<Self, J>
-        where J: SortedIterator<Item = Self::Item, Ordering = Self::Ordering>;
+    where
+        J: SortedIterator<Item = Self::Item, Ordering = Self::Ordering>;
 }
 
 impl<I> DifferenceExt for I
-    where I: SortedIterator,
-          I::Ordering: SortOrder<I::Item>
+where
+    I: SortedIterator,
+    I::Ordering: SortOrder<I::Item>,
 {
     fn difference<J>(self, j: J) -> Difference<Self, J>
-        where J: SortedIterator<Item = Self::Item, Ordering = Self::Ordering>
+    where
+        J: SortedIterator<Item = Self::Item, Ordering = Self::Ordering>,
     {
         Difference {
             i: self,

--- a/src/iter_intersection.rs
+++ b/src/iter_intersection.rs
@@ -1,13 +1,14 @@
-use std::cmp::Ordering;
 use super::{SortOrder, SortedIterator};
+use std::cmp::Ordering;
 
 /// Adaptor iterator which outputs the intersection of two sorted iterators in
 /// linear time. Will ouput the unique items (deduped).
 #[derive(Debug)]
 pub struct Intersection<I, J>
-    where I: SortedIterator,
-          I::Ordering: SortOrder<I::Item>,
-          J: SortedIterator<Item = I::Item, Ordering = I::Ordering>
+where
+    I: SortedIterator,
+    I::Ordering: SortOrder<I::Item>,
+    J: SortedIterator<Item = I::Item, Ordering = I::Ordering>,
 {
     i: I,
     j: J,
@@ -15,19 +16,20 @@ pub struct Intersection<I, J>
     b: Option<J::Item>,
 }
 
-
 impl<I, J> SortedIterator for Intersection<I, J>
-    where I: SortedIterator,
-          I::Ordering: SortOrder<I::Item>,
-          J: SortedIterator<Item = I::Item, Ordering = I::Ordering>
+where
+    I: SortedIterator,
+    I::Ordering: SortOrder<I::Item>,
+    J: SortedIterator<Item = I::Item, Ordering = I::Ordering>,
 {
     type Ordering = I::Ordering;
 }
 
 impl<I, J> Iterator for Intersection<I, J>
-    where I: SortedIterator,
-          I::Ordering: SortOrder<I::Item>,
-          J: SortedIterator<Item = I::Item, Ordering = I::Ordering>
+where
+    I: SortedIterator,
+    I::Ordering: SortOrder<I::Item>,
+    J: SortedIterator<Item = I::Item, Ordering = I::Ordering>,
 {
     type Item = I::Item;
 
@@ -36,34 +38,35 @@ impl<I, J> Iterator for Intersection<I, J>
             let a = self.a.take().or_else(|| self.i.next());
             let b = self.b.take().or_else(|| self.j.next());
             match (a, b) {
-                (Some(a), Some(b)) => {
-                    match I::Ordering::cmp(&a, &b) {
-                        Ordering::Equal => return Some(a),
-                        Ordering::Less => (),
-                        Ordering::Greater => (),
-                    }
-                }
+                (Some(a), Some(b)) => match I::Ordering::cmp(&a, &b) {
+                    Ordering::Equal => return Some(a),
+                    Ordering::Less => (),
+                    Ordering::Greater => (),
+                },
                 _ => return None,
             }
         }
     }
 }
 
-
 pub trait IntersectionExt
-    where Self: SortedIterator + Sized,
-          Self::Ordering: SortOrder<Self::Item>
+where
+    Self: SortedIterator + Sized,
+    Self::Ordering: SortOrder<Self::Item>,
 {
     fn intersection<J>(self, J) -> Intersection<Self, J>
-        where J: SortedIterator<Item = Self::Item, Ordering = Self::Ordering>;
+    where
+        J: SortedIterator<Item = Self::Item, Ordering = Self::Ordering>;
 }
 
 impl<I> IntersectionExt for I
-    where I: SortedIterator,
-          I::Ordering: SortOrder<I::Item>
+where
+    I: SortedIterator,
+    I::Ordering: SortOrder<I::Item>,
 {
     fn intersection<J>(self, j: J) -> Intersection<Self, J>
-        where J: SortedIterator<Item = Self::Item, Ordering = Self::Ordering>
+    where
+        J: SortedIterator<Item = Self::Item, Ordering = Self::Ordering>,
     {
         Intersection {
             i: self,

--- a/src/iter_intersection.rs
+++ b/src/iter_intersection.rs
@@ -2,7 +2,7 @@ use super::{SortOrder, SortedIterator};
 use std::cmp::Ordering;
 
 /// Adaptor iterator which outputs the intersection of two sorted iterators in
-/// linear time. Will ouput the unique items (deduped).
+/// linear time. Will ouput the repeated items as many times as they are present in both iterators.
 #[derive(Debug)]
 pub struct Intersection<I, J>
 where
@@ -40,8 +40,8 @@ where
             match (a, b) {
                 (Some(a), Some(b)) => match I::Ordering::cmp(&a, &b) {
                     Ordering::Equal => return Some(a),
-                    Ordering::Less => (),
-                    Ordering::Greater => (),
+                    Ordering::Less => self.b = Some(b),
+                    Ordering::Greater => self.a = Some(a),
                 },
                 _ => return None,
             }

--- a/src/iter_union.rs
+++ b/src/iter_union.rs
@@ -1,15 +1,15 @@
-use std::cmp::Ordering;
 use super::{SortOrder, SortedIterator};
-
+use std::cmp::Ordering;
 
 /// Adaptor iterator which outputs the union of two sorted iterators in
 /// linear time. Duplicates are preserved. It's suggested to adapt with dedup
 /// from crate itertools if you want a unique union.
 #[derive(Debug)]
 pub struct Union<I, J>
-    where I: SortedIterator,
-          I::Ordering: SortOrder<I::Item>,
-          J: SortedIterator<Item = I::Item, Ordering = I::Ordering>
+where
+    I: SortedIterator,
+    I::Ordering: SortOrder<I::Item>,
+    J: SortedIterator<Item = I::Item, Ordering = I::Ordering>,
 {
     i: I,
     j: J,
@@ -17,20 +17,20 @@ pub struct Union<I, J>
     b: Option<J::Item>,
 }
 
-
 impl<I, J> SortedIterator for Union<I, J>
-    where I: SortedIterator,
-          I::Ordering: SortOrder<I::Item>,
-          J: SortedIterator<Item = I::Item, Ordering = I::Ordering>
+where
+    I: SortedIterator,
+    I::Ordering: SortOrder<I::Item>,
+    J: SortedIterator<Item = I::Item, Ordering = I::Ordering>,
 {
     type Ordering = I::Ordering;
 }
 
-
 impl<I, J> Iterator for Union<I, J>
-    where I: SortedIterator,
-          I::Ordering: SortOrder<I::Item>,
-          J: SortedIterator<Item = I::Item, Ordering = I::Ordering>
+where
+    I: SortedIterator,
+    I::Ordering: SortOrder<I::Item>,
+    J: SortedIterator<Item = I::Item, Ordering = I::Ordering>,
 {
     type Item = I::Item;
     fn next(&mut self) -> Option<Self::Item> {
@@ -54,21 +54,24 @@ impl<I, J> Iterator for Union<I, J>
     }
 }
 
-
 pub trait UnionExt
-    where Self: SortedIterator + Sized,
-          Self::Ordering: SortOrder<Self::Item>
+where
+    Self: SortedIterator + Sized,
+    Self::Ordering: SortOrder<Self::Item>,
 {
     fn union<J>(self, J) -> Union<Self, J>
-        where J: SortedIterator<Ordering = Self::Ordering, Item = Self::Item>;
+    where
+        J: SortedIterator<Ordering = Self::Ordering, Item = Self::Item>;
 }
 
 impl<I> UnionExt for I
-    where I: SortedIterator,
-          I::Ordering: SortOrder<I::Item>
+where
+    I: SortedIterator,
+    I::Ordering: SortOrder<I::Item>,
 {
     fn union<J>(self, j: J) -> Union<Self, J>
-        where J: SortedIterator<Ordering = Self::Ordering, Item = Self::Item>
+    where
+        J: SortedIterator<Ordering = Self::Ordering, Item = Self::Item>,
     {
         Union {
             i: self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ pub use trait_collection::Collection;
 pub use trait_retains_order::RetainsOrder;
 pub use trait_searchable_by_order::SearchableByOrder;
 pub use trait_sort_order::keys;
-pub use trait_sort_order::{SortOrder, AscendingOrder, DescendingOrder, Key, KeyOrder};
+pub use trait_sort_order::{AscendingOrder, DescendingOrder, Key, KeyOrder, SortOrder};
 pub use trait_sortable::Sortable;
 pub use trait_sorted_insert::SortedInsert;
 pub use trait_sorted_iterator::SortedIterator;

--- a/src/sorted_iter.rs
+++ b/src/sorted_iter.rs
@@ -1,5 +1,5 @@
-use std::marker::PhantomData;
 use super::SortedIterator;
+use std::marker::PhantomData;
 
 #[derive(Debug)]
 pub struct SortedIter<I, O> {
@@ -8,7 +8,8 @@ pub struct SortedIter<I, O> {
 }
 
 impl<I, O> Iterator for SortedIter<I, O>
-    where I: Iterator
+where
+    I: Iterator,
 {
     type Item = I::Item;
     fn next(&mut self) -> Option<Self::Item> {
@@ -17,7 +18,8 @@ impl<I, O> Iterator for SortedIter<I, O>
 }
 
 impl<I, O> SortedIterator for SortedIter<I, O>
-    where I: Iterator
+where
+    I: Iterator,
 {
     type Ordering = O;
 }

--- a/src/std_slice.rs
+++ b/src/std_slice.rs
@@ -1,5 +1,5 @@
+use super::{Collection, RetainsOrder, SearchableByOrder, SortOrder, Sortable};
 use std::cmp::Ordering;
-use super::{Collection, SearchableByOrder, RetainsOrder, SortOrder, Sortable};
 
 // Impl traits for &mut [T].
 
@@ -9,14 +9,16 @@ impl<'a, T> Collection for &'a mut [T] {
 
 impl<'a, T> Sortable for &'a mut [T] {
     fn sort<F>(&mut self, f: F)
-        where F: FnMut(&Self::Item, &Self::Item) -> Ordering
+    where
+        F: FnMut(&Self::Item, &Self::Item) -> Ordering,
     {
         self.sort_by(f);
     }
 }
 
 impl<'a, T, O> SearchableByOrder<O> for &'a mut [T]
-    where O: SortOrder<T>
+where
+    O: SortOrder<T>,
 {
     fn search(&self, a: &T) -> Result<usize, usize> {
         self.binary_search_by(|b| O::cmp(a, b))
@@ -32,7 +34,8 @@ impl<'a, T> Collection for &'a [T] {
 }
 
 impl<'a, T, O> SearchableByOrder<O> for &'a [T]
-    where O: SortOrder<T>
+where
+    O: SortOrder<T>,
 {
     fn search(&self, a: &T) -> Result<usize, usize> {
         self.binary_search_by(|b| O::cmp(a, b))
@@ -48,7 +51,8 @@ impl<T> Collection for [T] {
 impl<T> RetainsOrder for [T] {}
 
 impl<T, O> SearchableByOrder<O> for [T]
-    where O: SortOrder<T>
+where
+    O: SortOrder<T>,
 {
     fn search(&self, a: &T) -> Result<usize, usize> {
         self.binary_search_by(|b| O::cmp(a, b))

--- a/src/std_vec.rs
+++ b/src/std_vec.rs
@@ -1,5 +1,5 @@
+use super::{Collection, RetainsOrder, SearchableByOrder, SortOrder, Sortable, SortedInsert};
 use std::cmp::Ordering;
-use super::{Collection, RetainsOrder, Sortable, SortedInsert, SortOrder, SearchableByOrder};
 
 impl<T> Collection for Vec<T> {
     type Item = T;
@@ -9,14 +9,16 @@ impl<T> RetainsOrder for Vec<T> {}
 
 impl<T> Sortable for Vec<T> {
     fn sort<F>(&mut self, f: F)
-        where F: FnMut(&Self::Item, &Self::Item) -> Ordering
+    where
+        F: FnMut(&Self::Item, &Self::Item) -> Ordering,
     {
         self.sort_by(f);
     }
 }
 
 impl<T, O> SearchableByOrder<O> for Vec<T>
-    where O: SortOrder<T>
+where
+    O: SortOrder<T>,
 {
     fn search(&self, a: &T) -> Result<usize, usize> {
         self.binary_search_by(|b| O::cmp(b, a))
@@ -24,8 +26,9 @@ impl<T, O> SearchableByOrder<O> for Vec<T>
 }
 
 impl<T, O> SortedInsert<O> for Vec<T>
-    where O: SortOrder<T>,
-          Self: Collection<Item = T> + SearchableByOrder<O>
+where
+    O: SortOrder<T>,
+    Self: Collection<Item = T> + SearchableByOrder<O>,
 {
     fn insert(&mut self, x: T) {
         let i = match self.search(&x) {

--- a/src/trait_searchable_by_order.rs
+++ b/src/trait_searchable_by_order.rs
@@ -4,7 +4,8 @@ use super::{Collection, SortOrder};
 
 /// Defines an interface for collections that can be searched when sorted.
 pub trait SearchableByOrder<O>: Collection
-    where O: SortOrder<Self::Item>
+where
+    O: SortOrder<Self::Item>,
 {
     fn search(&self, &Self::Item) -> Result<usize, usize>;
 }

--- a/src/trait_sort_order.rs
+++ b/src/trait_sort_order.rs
@@ -1,7 +1,7 @@
 use std::cmp::Ordering;
 use std::marker::PhantomData;
 
-use super::{Sorted, Sortable};
+use super::{Sortable, Sorted};
 
 pub trait SortOrder<T>: Clone + Copy {
     fn cmp(&T, &T) -> Ordering;
@@ -15,7 +15,8 @@ pub trait SortOrder<T>: Clone + Copy {
 pub struct AscendingOrder;
 
 impl<T> SortOrder<T> for AscendingOrder
-    where T: Ord + Clone
+where
+    T: Ord + Clone,
 {
     fn cmp(a: &T, b: &T) -> Ordering {
         a.cmp(b)
@@ -26,13 +27,13 @@ impl<T> SortOrder<T> for AscendingOrder
 pub struct DescendingOrder;
 
 impl<T> SortOrder<T> for DescendingOrder
-    where T: Ord + Clone
+where
+    T: Ord + Clone,
 {
     fn cmp(a: &T, b: &T) -> Ordering {
         b.cmp(a)
     }
 }
-
 
 #[derive(Debug, Clone, Copy)]
 pub struct KeyOrder<K, O> {
@@ -40,8 +41,9 @@ pub struct KeyOrder<K, O> {
 }
 
 impl<T, K, O> SortOrder<T> for KeyOrder<K, O>
-    where K: Key<T> + Copy,
-          O: SortOrder<K::Key>
+where
+    K: Key<T> + Copy,
+    O: SortOrder<K::Key>,
 {
     fn cmp(a: &T, b: &T) -> Ordering {
         O::cmp(&K::key(a), &K::key(b))

--- a/src/trait_sortable.rs
+++ b/src/trait_sortable.rs
@@ -1,11 +1,12 @@
-use std::cmp::Ordering;
 use super::Collection;
-
+use std::cmp::Ordering;
 
 /// Implements an interface for collections that can be sorted.
 ///
 /// A collection that implements this trait must
 /// be able to re-order its elements in a specific order (sorting).
 pub trait Sortable: Collection {
-    fn sort<F>(&mut self, f: F) where F: FnMut(&Self::Item, &Self::Item) -> Ordering;
+    fn sort<F>(&mut self, f: F)
+    where
+        F: FnMut(&Self::Item, &Self::Item) -> Ordering;
 }

--- a/src/trait_sorted_insert.rs
+++ b/src/trait_sorted_insert.rs
@@ -1,7 +1,8 @@
 use super::{SearchableByOrder, SortOrder};
 
 pub trait SortedInsert<O>: SearchableByOrder<O>
-    where O: SortOrder<Self::Item>
+where
+    O: SortOrder<Self::Item>,
 {
     fn insert(&mut self, Self::Item);
 }

--- a/src/type_sorted.rs
+++ b/src/type_sorted.rs
@@ -1,10 +1,11 @@
-
 use std::iter::FromIterator;
 
-use std::ops::Deref;
+use super::{
+    Collection, RetainsOrder, SearchableByOrder, SortOrder, Sortable, SortedInsert, SortedIter,
+    SortedIterator,
+};
 use std::marker::PhantomData;
-use super::{Collection, RetainsOrder, SortOrder, Sortable, SortedInsert, SortedIter,
-            SortedIterator, SearchableByOrder};
+use std::ops::Deref;
 
 /// Guarantees that the inner container is sorted in a specific order.
 ///
@@ -19,18 +20,17 @@ pub struct Sorted<T, O> {
     ordering: PhantomData<O>,
 }
 
-
-impl<T, O> Default for Sorted<T, O> 
-    where T: Default + Collection
+impl<T, O> Default for Sorted<T, O>
+where
+    T: Default + Collection,
 {
     fn default() -> Self {
         Sorted {
             collection: Default::default(),
-            ordering: PhantomData
+            ordering: PhantomData,
         }
     }
 }
-
 
 impl<T, O> Sorted<T, O> {
     pub fn as_inner(&self) -> &T {
@@ -38,8 +38,9 @@ impl<T, O> Sorted<T, O> {
     }
 
     pub fn deref_inner<'a, U>(&'a self) -> Sorted<&'a U, O>
-        where U: ?Sized,
-              T: Deref<Target = U>
+    where
+        U: ?Sized,
+        T: Deref<Target = U>,
     {
         Sorted {
             collection: Deref::deref(&self.collection),
@@ -48,7 +49,8 @@ impl<T, O> Sorted<T, O> {
     }
 
     pub fn iter<'a>(&'a self) -> SortedIter<<&T as IntoIterator>::IntoIter, O>
-        where &'a T: IntoIterator
+    where
+        &'a T: IntoIterator,
     {
         SortedIter {
             inner: IntoIterator::into_iter(&self.collection),
@@ -69,8 +71,9 @@ impl<T, O> Sorted<T, O> {
     // would be n x n implementations of the type.
     #[cfg(feature = "unstable")]
     pub fn from<'b, U>(sorted: Sorted<U, O>) -> Self
-        where T: From<U>,
-              U: Sortable
+    where
+        T: From<U>,
+        U: Sortable,
     {
         Sorted {
             collection: From::from(sorted.collection),
@@ -85,10 +88,11 @@ impl<T, O> Sorted<T, O> {
     /// iterator must implement SortedIterator, you'll safely get a sorted collection.
     /// [`Sortable`]: trait.Sortable.html
     pub fn from_iter<I>(iter: I) -> Sorted<T, O>
-        where T: RetainsOrder + FromIterator<<T as Collection>::Item>,
-              I: IntoIterator<Item = T::Item>,
-              I::IntoIter: SortedIterator<Ordering = O>,
-              <I as IntoIterator>::IntoIter: SortedIterator<Ordering = O>
+    where
+        T: RetainsOrder + FromIterator<<T as Collection>::Item>,
+        I: IntoIterator<Item = T::Item>,
+        I::IntoIter: SortedIterator<Ordering = O>,
+        <I as IntoIterator>::IntoIter: SortedIterator<Ordering = O>,
     {
         Sorted {
             collection: iter.into_iter().collect(),
@@ -98,8 +102,9 @@ impl<T, O> Sorted<T, O> {
 }
 
 impl<T, O> Sorted<T, O>
-    where T: Sortable,
-          O: SortOrder<T::Item>
+where
+    T: Sortable,
+    O: SortOrder<T::Item>,
 {
     pub fn by_sorting(mut collection: T) -> Self {
         collection.sort(O::cmp);
@@ -111,8 +116,9 @@ impl<T, O> Sorted<T, O>
 }
 
 impl<T, O> Sorted<T, O>
-    where T: SearchableByOrder<O>,
-          O: SortOrder<T::Item>
+where
+    T: SearchableByOrder<O>,
+    O: SortOrder<T::Item>,
 {
     pub fn search(&self, a: &T::Item) -> Result<usize, usize> {
         self.collection.search(a)
@@ -120,8 +126,9 @@ impl<T, O> Sorted<T, O>
 }
 
 impl<T, O> Sorted<T, O>
-    where T: Sortable + SortedInsert<O>,
-          O: SortOrder<T::Item>
+where
+    T: Sortable + SortedInsert<O>,
+    O: SortOrder<T::Item>,
 {
     pub fn insert(&mut self, x: T::Item) {
         self.collection.insert(x)
@@ -131,8 +138,9 @@ impl<T, O> Sorted<T, O>
 impl<T, O> Sorted<T, O> {
     /// Similar to Option::as_ref. It's mapping the inner type with AsRef.
     pub fn as_ref<U>(&self) -> Sorted<&U, O>
-        where T: AsRef<U>,
-              U: ?Sized + RetainsOrder
+    where
+        T: AsRef<U>,
+        U: ?Sized + RetainsOrder,
     {
         Sorted {
             collection: AsRef::as_ref(&self.collection),
@@ -149,7 +157,8 @@ impl<T, O> Deref for Sorted<T, O> {
 }
 
 impl<T, O> IntoIterator for Sorted<T, O>
-    where T: IntoIterator<Item = <T as Collection>::Item> + Sortable
+where
+    T: IntoIterator<Item = <T as Collection>::Item> + Sortable,
 {
     type Item = <T as Collection>::Item;
     type IntoIter = SortedIter<T::IntoIter, O>;

--- a/tests/iterators.rs
+++ b/tests/iterators.rs
@@ -1,41 +1,29 @@
 extern crate sorted;
 use sorted::*;
 
-
-
 #[test]
 fn union_iter() {
-    let v0 = AscendingOrder::by_sorting(vec![1,3,4,5,5,10]);
-    let v1 = AscendingOrder::by_sorting(vec![0,2,4,4,7,11,11,23]);
-    let v2 = Sorted::<Vec<u32>,_>::from_iter(v1.into_iter().union(v0.into_iter()));
+    let v0 = AscendingOrder::by_sorting(vec![1, 3, 4, 5, 5, 10]);
+    let v1 = AscendingOrder::by_sorting(vec![0, 2, 4, 4, 7, 11, 11, 23]);
+    let v2 = Sorted::<Vec<u32>, _>::from_iter(v1.into_iter().union(v0.into_iter()));
     assert_eq!(
-        [0,1,2,3,4,4,4,5,5,7,10,11,11,23],
+        [0, 1, 2, 3, 4, 4, 4, 5, 5, 7, 10, 11, 11, 23],
         v2.as_slice()
     );
 }
 
 #[test]
 fn difference_iter() {
-    let v0 = AscendingOrder::by_sorting(vec![1,2,2,3,4,4,5]);
-    let v1 = AscendingOrder::by_sorting(vec![0,1,3,3,4,6,7,7,9]);
-    let v2 = Sorted::<Vec<_>,_>::from_iter(
-        v0.into_iter().difference(v1.into_iter())
-    );
-    assert_eq!(
-        [2,2,5],
-        v2.as_slice()
-    );
+    let v0 = AscendingOrder::by_sorting(vec![1, 2, 2, 3, 4, 4, 5]);
+    let v1 = AscendingOrder::by_sorting(vec![0, 1, 3, 3, 4, 6, 7, 7, 9]);
+    let v2 = Sorted::<Vec<_>, _>::from_iter(v0.into_iter().difference(v1.into_iter()));
+    assert_eq!([2, 2, 5], v2.as_slice());
 }
 
 #[test]
 fn intersection_iter() {
-    let v0 = AscendingOrder::by_sorting(vec![1,2,5,6,6,8,9,9]);
-    let v1 = AscendingOrder::by_sorting(vec![1,1,3,6,7,9,9,10]);
-    let v2 = Sorted::<Vec<_>,_>::from_iter(
-        v0.into_iter().intersection(v1.into_iter())
-    );
-    assert_eq!(
-        [1,6,9],
-        v2.as_slice()
-    );
+    let v0 = AscendingOrder::by_sorting(vec![1, 2, 5, 6, 6, 8, 9, 9]);
+    let v1 = AscendingOrder::by_sorting(vec![1, 1, 3, 6, 7, 9, 9, 10]);
+    let v2 = Sorted::<Vec<_>, _>::from_iter(v0.into_iter().intersection(v1.into_iter()));
+    assert_eq!([1, 6, 9], v2.as_slice());
 }

--- a/tests/iterators.rs
+++ b/tests/iterators.rs
@@ -22,8 +22,8 @@ fn difference_iter() {
 
 #[test]
 fn intersection_iter() {
-    let v0 = AscendingOrder::by_sorting(vec![1, 2, 5, 6, 6, 8, 9, 9]);
+    let v0 = AscendingOrder::by_sorting(vec![1, 1, 2, 5, 5, 6, 6, 8, 9, 9]);
     let v1 = AscendingOrder::by_sorting(vec![1, 1, 3, 6, 7, 9, 9, 10]);
     let v2 = Sorted::<Vec<_>, _>::from_iter(v0.into_iter().intersection(v1.into_iter()));
-    assert_eq!([1, 6, 9], v2.as_slice());
+    assert_eq!([1, 1, 6, 9, 9], v2.as_slice());
 }

--- a/tests/usage.rs
+++ b/tests/usage.rs
@@ -3,11 +3,11 @@ extern crate sorted;
 
 use sorted::*;
 
-order_by_key!{ Key0AscOrder:
+order_by_key! { Key0AscOrder:
     fn (K: Ord + Copy, T)(entry: (K,T)) -> K { entry.0 }
 }
 
-order_by_key!{ KeySecondOrder:
+order_by_key! { KeySecondOrder:
     fn (K: Ord + Copy, T)(entry: (T,K)) -> K { entry.1 }
 }
 
@@ -89,11 +89,15 @@ fn sort_with_property_key_type() {
     }
 
     // You can now sort the Records by a property in any order.
-    let v = KeyOrder::<IdKey, AscendingOrder>::by_sorting(vec![Record::new(2),
-                                                               Record::new(3),
-                                                               Record::new(1)]);
-    assert_eq!(&v.as_slice(),
-               &[Record::new(1), Record::new(2), Record::new(3)]);
+    let v = KeyOrder::<IdKey, AscendingOrder>::by_sorting(vec![
+        Record::new(2),
+        Record::new(3),
+        Record::new(1),
+    ]);
+    assert_eq!(
+        &v.as_slice(),
+        &[Record::new(1), Record::new(2), Record::new(3)]
+    );
 }
 
 #[test]
@@ -128,13 +132,19 @@ fn sort_by_property_string() {
     // It will only provide one ordering for what you define, so if you need to
     // support multiple ways of ordering by name it will result in a bit of
     // boilerplate.
-    let v = OrderByName::by_sorting(vec![Person::new("Bob"),
-                                         Person::new("Cecil"),
-                                         Person::new("Alice")]);
-    assert_eq!(v.as_slice(),
-               &[Person::new("Alice"),
-                 Person::new("Bob"),
-                 Person::new("Cecil")]);
+    let v = OrderByName::by_sorting(vec![
+        Person::new("Bob"),
+        Person::new("Cecil"),
+        Person::new("Alice"),
+    ]);
+    assert_eq!(
+        v.as_slice(),
+        &[
+            Person::new("Alice"),
+            Person::new("Bob"),
+            Person::new("Cecil")
+        ]
+    );
 }
 
 #[test]
@@ -159,7 +169,7 @@ fn sorted_vec_ref() {
 }
 
 #[test]
-#[cfg(feature="unstable")]
+#[cfg(feature = "unstable")]
 fn sorted_vec_from_sorted_slice() {
     type SortedVec<T, O> = Sorted<Vec<T>, O>;
     let mut arr = [5, 3, 7, 9];
@@ -173,8 +183,9 @@ fn sorted_vec_from_sorted_slice() {
 fn take_sorted_iterator() {
     // Sorted types can generate SortedIterators.
     fn take_sorted<I>(sorted: I)
-        where I: IntoIterator<Item = i32>,
-              I::IntoIter: SortedIterator<Ordering = AscendingOrder>
+    where
+        I: IntoIterator<Item = i32>,
+        I::IntoIter: SortedIterator<Ordering = AscendingOrder>,
     {
         let v: Vec<_> = sorted.into_iter().collect();
         assert_eq!(vec![2, 3, 8, 10], v);
@@ -188,8 +199,9 @@ fn take_sorted_ref_iterator() {
     // By-ref iterators can only be created via Sorted::iter() right now.
     // I.e there is no IntoIterator for &Sorted<>.
     fn take_sorted_ref<'a, I>(sorted: I)
-        where I: IntoIterator<Item = &'a i32>,
-              I::IntoIter: SortedIterator
+    where
+        I: IntoIterator<Item = &'a i32>,
+        I::IntoIter: SortedIterator,
     {
         let v: Vec<_> = sorted.into_iter().cloned().collect();
         assert_eq!([1, 2, 3, 4], v.as_slice());
@@ -219,9 +231,9 @@ fn sorted_vec_from_sorted_iterator() {
 
 #[test]
 fn building_from_empty_vec() {
-    let mut v: Sorted<Vec<i32>,AscendingOrder> = Default::default();
+    let mut v: Sorted<Vec<i32>, AscendingOrder> = Default::default();
     v.insert(3);
     v.insert(1);
     v.insert(2);
-    assert_eq!(&[1,2,3], v.as_slice());
+    assert_eq!(&[1, 2, 3], v.as_slice());
 }


### PR DESCRIPTION
Previous implementation did not detect correctly intersecting elements when they are a different indexes.

Changed the spec for the function to include duplicated elements as it seems to be more natural, and a deduplicated iterator can be obtained using `dedup` adaptor from `itertools` where as obtaining the duplicated iterator from the deduplicated one is not easy.

I can remove the `rustfmt` reformatting commit if needed.